### PR TITLE
Update SoapRfcWebClient.cs

### DIFF
--- a/src/plain/PlainRfcPreparedFunction.cs
+++ b/src/plain/PlainRfcPreparedFunction.cs
@@ -94,7 +94,7 @@ namespace SharpSapRfc.Plain
                 if (ex.GetBaseException() is SharpRfcException)
                     throw ex;
 
-                throw new SharpRfcCallException(ex.Message, function.ToString(), ex);
+                throw new SharpRfcCallException(ex.Message, function == null ? "null" : function.ToString(), ex);
             }
         }
 
@@ -112,7 +112,7 @@ namespace SharpSapRfc.Plain
                 if (ex.GetBaseException() is SharpRfcException)
                     throw ex;
 
-                throw new SharpRfcCallException(ex.Message, function.ToString(), ex);
+                throw new SharpRfcCallException(ex.Message, function == null ? "null" : function.ToString(), ex);
             }
 
             return new PlainRfcResult(function, this.structureMapper);

--- a/src/soap/SoapRfcWebClient.cs
+++ b/src/soap/SoapRfcWebClient.cs
@@ -60,6 +60,14 @@ namespace SharpSapRfc.Soap
                 var response = ex.Response as HttpWebResponse;
                 if (response != null)
                 {
+                    // this is to prevent that "META start tag" error string
+                    // and throw error status "Unathorized" from StatusCode
+                    // hence more meaningful
+                    if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        throw ex;
+                    }
+                    
                     using (StreamReader rd = new StreamReader(response.GetResponseStream()))
                         responseXml.Load(rd);
                 }


### PR DESCRIPTION
This is to prevent that "META start tag" error string and throw error status "Unathorized" from StatusCode hence more meaningful.

The second changes was to remove the "object ref not set" as per commit notes.